### PR TITLE
Prevent ProductDrawer to close when click outside of it

### DIFF
--- a/product/components/ProductDrawer.tsx
+++ b/product/components/ProductDrawer.tsx
@@ -22,9 +22,10 @@ interface Props {
 
 const ProductDrawer: React.FC<Props> = ({isOpen, defaultValues, onClose, onSubmit}) => {
   const isNew = Boolean(!defaultValues?.id);
+  const closeOnOverlayClick = false;
 
   return (
-    <Drawer id="product" isOpen={isOpen} placement="right" size="md" onClose={onClose}>
+    <Drawer id="product" isOpen={isOpen} placement="right" size="md" onClose={onClose} closeOnOverlayClick={closeOnOverlayClick}>
       <DrawerOverlay />
       <DrawerContent>
         <DrawerCloseButton right="8px" top="8px" />

--- a/product/components/ProductDrawer.tsx
+++ b/product/components/ProductDrawer.tsx
@@ -25,7 +25,7 @@ const ProductDrawer: React.FC<Props> = ({isOpen, defaultValues, onClose, onSubmi
   const closeOnOverlayClick = false;
 
   return (
-    <Drawer id="product" isOpen={isOpen} placement="right" size="md" onClose={onClose} closeOnOverlayClick={closeOnOverlayClick}>
+    <Drawer id="product" isOpen={isOpen} placement="right" size="md" onClose={onClose} closeOnOverlayClick={false}>
       <DrawerOverlay />
       <DrawerContent>
         <DrawerCloseButton right="8px" top="8px" />

--- a/product/components/ProductDrawer.tsx
+++ b/product/components/ProductDrawer.tsx
@@ -22,7 +22,6 @@ interface Props {
 
 const ProductDrawer: React.FC<Props> = ({isOpen, defaultValues, onClose, onSubmit}) => {
   const isNew = Boolean(!defaultValues?.id);
-  const closeOnOverlayClick = false;
 
   return (
     <Drawer id="product" isOpen={isOpen} placement="right" size="md" onClose={onClose} closeOnOverlayClick={false}>


### PR DESCRIPTION
Fixes #56 -Eliminar la función de cancelar haciendo click fuera de la caja