### PR TITLE
Implements Error Service

### DIFF
--- a/errors/index.ts
+++ b/errors/index.ts
@@ -1,0 +1,18 @@
+import ErrorProvider, {ErrorInfo} from "./provider";
+
+export * from "./providers";
+export {ErrorInfo};
+
+export default class ErrorService {
+  constructor(private readonly provider: ErrorProvider) {
+    if (process.env.NODE_ENV === "production") {
+      this.provider.initialize();
+    }
+  }
+
+  reportError(error: Error, errorInfo: ErrorInfo) {
+    if (process.env.NODE_ENV === "production") {
+      this.provider.captureError(error, errorInfo);
+    }
+  }
+}

--- a/errors/provider.ts
+++ b/errors/provider.ts
@@ -1,0 +1,8 @@
+export type ErrorInfo = React.ErrorInfo & {
+  origin: string;
+};
+
+export default interface ErrorProvider {
+  initialize(): void;
+  captureError(error: Error, errorInfo: object): void;
+}

--- a/errors/providers/index.ts
+++ b/errors/providers/index.ts
@@ -1,0 +1,1 @@
+export * from "./sentry";

--- a/errors/providers/sentry.ts
+++ b/errors/providers/sentry.ts
@@ -1,0 +1,27 @@
+import * as Sentry from "@sentry/browser";
+
+import ErrorProvider, {ErrorInfo} from "../provider";
+
+export class SentryErrorProvider implements ErrorProvider {
+  initialize() {
+    if (process.env.SENTRY_DSN) {
+      Sentry.init({
+        dsn: process.env.SENTRY_DSN,
+      });
+    }
+  }
+
+  captureError(error: Error, errorInfo: ErrorInfo) {
+    Sentry.withScope((scope) => {
+      scope.setTag("origin", errorInfo.origin);
+
+      Object.keys(errorInfo).forEach((key) => {
+        scope.setExtra(key, errorInfo[key]);
+      });
+
+      scope.setExtra("error", error);
+
+      Sentry.captureException(error);
+    });
+  }
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,32 +1,16 @@
 import React from "react";
 import App from "next/app";
-import * as Sentry from "@sentry/browser";
 import {Flex, ThemeProvider, CSSReset} from "@chakra-ui/core";
+
+import ErrorService, {ErrorInfo, SentryErrorProvider} from "../errors";
 
 import ErrorScreen from "./_error";
 
-if (process.env.NODE_ENV === "production" && process.env.SENTRY_DSN) {
-  Sentry.init({
-    dsn: process.env.SENTRY_DSN,
-  });
-}
+const errorService = new ErrorService(new SentryErrorProvider());
 
 export default class Pency extends App {
-  componentDidCatch(error, errorInfo) {
-    if (process.env.NODE_ENV === "production" && process.env.SENTRY_DSN) {
-      Sentry.withScope((scope) => {
-        scope.setTag("origin", "componentDidCatch");
-
-        Object.keys(errorInfo).forEach((key) => {
-          scope.setExtra(key, errorInfo[key]);
-        });
-
-        scope.setExtra("error", error);
-
-        Sentry.captureException(error);
-      });
-    }
-
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    errorService.reportError(error, errorInfo);
     super.componentDidCatch(error, errorInfo);
   }
 


### PR DESCRIPTION
Resolves #96.

Instead of calling directly to the Sentry SDK, we now wrap it around a class `ErrorService` that receives an instance of any given `ErrorProvider`. I moved the Sentry-specific logic to its own `SentryErrorProvider` class.