### PR TITLE
hotfix: add overflow wrap to product title 

### DIFF
--- a/cart/components/CartItemDrawer/CartItemDrawer.tsx
+++ b/cart/components/CartItemDrawer/CartItemDrawer.tsx
@@ -153,7 +153,7 @@ const CartItemDrawer: React.FC<Props> = ({onClose, product, onSubmit, ...props})
                   spacing={6}
                 >
                   <Stack spacing={2}>
-                    <Text fontSize="2xl" fontWeight="bold" lineHeight="normal">
+                    <Text fontSize="2xl" fontWeight="bold" lineHeight="normal" overflowWrap="break-word">
                       {product.title}
                     </Text>
                     {product.description && (

--- a/cart/components/CartSummaryDrawer/Overview.tsx
+++ b/cart/components/CartSummaryDrawer/Overview.tsx
@@ -79,7 +79,7 @@ const Overview: React.FC<Props> = ({
               <Flex key={id} alignItems="flex-start" justifyContent="space-between">
                 <Flex alignItems="center" mr={2}>
                   <Stack spacing={0}>
-                    <Text fontWeight={500}>{product.title}</Text>
+                    <Text fontWeight={500} maxWidth={{ base: "2xs", lg: "xs"}} overflowWrap="break-word">{product.title}</Text>
                     {variants && <Text color="gray.600">{getVariantsString(variants)}</Text>}
                     {note && <Text color="gray.600">({note})</Text>}
                     <Stepper

--- a/product/components/ProductCard/Portrait.tsx
+++ b/product/components/ProductCard/Portrait.tsx
@@ -54,7 +54,7 @@ const PortraitProductCard: React.FC<Props> = ({isRaised = false, product, onClic
         paddingTop={2}
         width="100%"
       >
-        <Text display="block" fontSize="md" fontWeight={500} lineHeight="normal" marginBottom={2}>
+        <Text display="block" fontSize="md" fontWeight={500} lineHeight="normal" marginBottom={2} overflowWrap="break-word">
           {title}
         </Text>
         {type === "available" && (


### PR DESCRIPTION
Resolves #164 
Impact **minor**
Type **bug**


### Issue

When the product title contains a word that is too long, it breaks the layout that contains it

### Solution

Add the prop `overflowWrap="break-word"` to all the components that use the product title only on the store

